### PR TITLE
chore/wip

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -727,7 +727,27 @@ require('lazy').setup({
             client.server_capabilities.documentRangeFormattingProvider = false
           end,
         },
-        basedpyright = {},
+        -- ruff = {},
+        -- pyright = {},
+        basedpyright = {
+          settings = {
+            basedpyright = {
+              analysis = {
+                typeCheckingMode = 'basic',
+                autoImportCompletions = true,
+                diagnosticSeverityOverrides = {
+                  reportUnusedImport = 'information',
+                  reportUnusedFunction = 'information',
+                  reportUnusedVariable = 'information',
+                  reportGeneralTypeIssues = 'none',
+                  reportOptionalMemberAccess = 'none',
+                  reportOptionalSubscript = 'none',
+                  reportPrivateImportUsage = 'none',
+                },
+              },
+            },
+          },
+        },
       }
 
       -- Ensure the servers and tools above are installed

--- a/init.lua
+++ b/init.lua
@@ -1194,3 +1194,15 @@ vim.keymap.set('i', '<C-J>', '<Plug>(copilot-accept-line)')
 vim.keymap.set('i', '<C-d>', '<Plug>(copilot-dismiss)')
 
 vim.api.nvim_set_keymap('n', '<leader>gB', '<cmd>BlameToggle<cr>', { noremap = true, silent = true, desc = 'Toggle Git Blame' })
+
+local function quick_chat(selection_type)
+  return function()
+    vim.ui.input({ prompt = 'Quick Chat: ' }, function(input)
+      if input ~= nil and input ~= '' then
+        require('CopilotChat').ask(input, { selection = require('CopilotChat.select')[selection_type] })
+      end
+    end)
+  end
+end
+
+vim.keymap.set('v', '<leader>p', quick_chat 'visual', { desc = 'Quick Chat' })

--- a/init.lua
+++ b/init.lua
@@ -878,6 +878,7 @@ require('lazy').setup({
       },
 
       completion = {
+        list = { selection = { preselect = false, auto_insert = true } },
         -- By default, you may press `<c-space>` to show the documentation.
         -- Optionally, set `auto_show = true` to show the documentation after a delay.
         documentation = { auto_show = false, auto_show_delay_ms = 500 },

--- a/init.lua
+++ b/init.lua
@@ -1190,7 +1190,7 @@ vim.api.nvim_set_keymap('n', '<leader>gc', ':lua require("telescope.builtin").gi
 vim.api.nvim_set_keymap( 'n', '<leader>gb', ':lua require("telescope.builtin").git_branches()<CR>', { noremap = true, silent = true, desc = 'Show Git Branches' })
 
 vim.keymap.set('i', '<C-L>', '<Plug>(copilot-accept-word)')
-
 vim.keymap.set('i', '<C-J>', '<Plug>(copilot-accept-line)')
+vim.keymap.set('i', '<C-d>', '<Plug>(copilot-dismiss)')
 
 vim.api.nvim_set_keymap('n', '<leader>gB', '<cmd>BlameToggle<cr>', { noremap = true, silent = true, desc = 'Toggle Git Blame' })

--- a/init.lua
+++ b/init.lua
@@ -1048,7 +1048,7 @@ require('lazy').setup({
 
 vim.cmd.colorscheme 'monet'
 vim.o.laststatus = 3
-vim.opt.cmdheight = 0
+vim.opt.cmdheight = 1
 
 vim.keymap.set('n', '<leader>w', ':write<CR>', { desc = 'Save buffer' })
 vim.keymap.set('n', '<leader>Q', ':qa<CR>', { desc = 'Quit Neovim' })

--- a/init.lua
+++ b/init.lua
@@ -812,6 +812,32 @@ require('lazy').setup({
     event = 'VimEnter',
     version = '1.*',
     dependencies = {
+      -- Snippet Engine
+      -- {
+      --   'L3MON4D3/LuaSnip',
+      --   version = '2.*',
+      --   build = (function()
+      --     -- Build Step is needed for regex support in snippets.
+      --     -- This step is not supported in many windows environments.
+      --     -- Remove the below condition to re-enable on windows.
+      --     if vim.fn.has 'win32' == 1 or vim.fn.executable 'make' == 0 then
+      --       return
+      --     end
+      --     return 'make install_jsregexp'
+      --   end)(),
+      --   dependencies = {
+      --     -- `friendly-snippets` contains a variety of premade snippets.
+      --     --    See the README about individual language/framework/plugin snippets:
+      --     --    https://github.com/rafamadriz/friendly-snippets
+      --     {
+      --       'rafamadriz/friendly-snippets',
+      --       config = function()
+      --         require('luasnip.loaders.from_vscode').lazy_load()
+      --       end,
+      --     },
+      --   },
+      --   opts = {},
+      -- },
       'folke/lazydev.nvim',
     },
     --- @module 'blink.cmp'
@@ -1002,12 +1028,13 @@ require('lazy').setup({
 vim.cmd.colorscheme 'monet'
 vim.o.laststatus = 3
 vim.opt.cmdheight = 0
+
 vim.keymap.set('n', '<leader>w', ':write<CR>', { desc = 'Save buffer' })
 vim.keymap.set('n', '<leader>Q', ':qa<CR>', { desc = 'Quit Neovim' })
 vim.keymap.set('n', 'H', ':bprevious<CR>', { desc = 'Go to previous buffer' })
 vim.keymap.set('n', 'L', ':bnext<CR>', { desc = 'Go to next buffer' })
-vim.keymap.set('n', '|', ':split<CR>', { desc = 'Horizontal split' })
-vim.keymap.set('n', '\\', ':vsplit<CR>', { desc = 'Vertical split' })
+vim.keymap.set('n', '|', ':vsplit<CR>', { desc = 'Horizontal split' })
+vim.keymap.set('n', '\\', ':split<CR>', { desc = 'Vertical split' })
 vim.keymap.set('n', '<C-q>', ':close<CR>', { desc = 'Close window' })
 
 vim.api.nvim_create_user_command('CopyBufferPath', function()

--- a/init.lua
+++ b/init.lua
@@ -258,7 +258,7 @@ rtp:prepend(lazypath)
 -- NOTE: Here is where you install your plugins.
 require('lazy').setup({
   -- NOTE: Plugins can be added with a link (or for a github repo: 'owner/repo' link).
-  'NMAC427/guess-indent.nvim', -- Detect tabstop and shiftwidth automatically
+  -- 'NMAC427/guess-indent.nvim', -- Detect tabstop and shiftwidth automatically
 
   -- NOTE: Plugins can also be added by using a table,
   -- with the first argument being the link and the following
@@ -724,12 +724,39 @@ require('lazy').setup({
             },
           },
         },
-        vtsls = {
-          on_attach = function(client, bufnr)
-            client.server_capabilities.documentFormattingProvider = false
-            client.server_capabilities.documentRangeFormattingProvider = false
-          end,
-        },
+        -- vtsls = {
+        --   settings = {
+        --     typescript = {
+        --       updateImportsOnFileMove = { enabled = 'always' },
+        --       inlayHints = {
+        --         parameterNames = { enabled = 'all' },
+        --         parameterTypes = { enabled = true },
+        --         variableTypes = { enabled = true },
+        --         propertyDeclarationTypes = { enabled = true },
+        --         functionLikeReturnTypes = { enabled = true },
+        --         enumMemberValues = { enabled = true },
+        --       },
+        --     },
+        --     javascript = {
+        --       updateImportsOnFileMove = { enabled = 'always' },
+        --       inlayHints = {
+        --         parameterNames = { enabled = 'literals' },
+        --         parameterTypes = { enabled = true },
+        --         variableTypes = { enabled = true },
+        --         propertyDeclarationTypes = { enabled = true },
+        --         functionLikeReturnTypes = { enabled = true },
+        --         enumMemberValues = { enabled = true },
+        --       },
+        --     },
+        --     vtsls = {
+        --       enableMoveToFileCodeAction = true,
+        --     },
+        --   },
+        --   on_attach = function(client, bufnr)
+        --     client.server_capabilities.documentFormattingProvider = false
+        --     client.server_capabilities.documentRangeFormattingProvider = false
+        --   end,
+        -- },
         -- ruff = {},
         -- pyright = {},
         basedpyright = {

--- a/init.lua
+++ b/init.lua
@@ -94,12 +94,12 @@ vim.g.maplocalleader = ' '
 vim.g.have_nerd_font = true
 
 -- [[ Setting options ]]
--- See `:help vim.opt`
+-- See `:help vim.o`
 -- NOTE: You can change these options as you wish!
 --  For more options, you can see `:help option-list`
 
 -- Make line numbers default
-vim.opt.number = true
+vim.o.number = true
 -- You can also add relative line numbers, to help with jumping.
 --  Experiment for yourself to see if you like it!
 vim.opt.relativenumber = true
@@ -108,58 +108,58 @@ vim.opt.relativenumber = true
 vim.opt.mouse = 'a'
 
 -- Don't show the mode, since it's already in the status line
-vim.opt.showmode = false
+vim.o.showmode = false
 
 -- Sync clipboard between OS and Neovim.
 --  Schedule the setting after `UiEnter` because it can increase startup-time.
 --  Remove this option if you want your OS clipboard to remain independent.
 --  See `:help 'clipboard'`
 vim.schedule(function()
-  vim.opt.clipboard = 'unnamedplus'
+  vim.o.clipboard = 'unnamedplus'
 end)
 
 -- Enable break indent
-vim.opt.breakindent = true
+vim.o.breakindent = true
 
 -- Save undo history
-vim.opt.undofile = true
+vim.o.undofile = true
 
 -- Case-insensitive searching UNLESS \C or one or more capital letters in the search term
-vim.opt.ignorecase = true
-vim.opt.smartcase = true
+vim.o.ignorecase = true
+vim.o.smartcase = true
 
 -- Keep signcolumn on by default
-vim.opt.signcolumn = 'no'
+vim.o.signcolumn = 'no'
 
 -- Decrease update time
-vim.opt.updatetime = 250
+vim.o.updatetime = 250
 
 -- Decrease mapped sequence wait time
-vim.opt.timeoutlen = 300
+vim.o.timeoutlen = 300
 
 -- Configure how new splits should be opened
-vim.opt.splitright = true
-vim.opt.splitbelow = true
+vim.o.splitright = true
+vim.o.splitbelow = true
 
 -- Sets how neovim will display certain whitespace characters in the editor.
 --  See `:help 'list'`
 --  and `:help 'listchars'`
-vim.opt.list = true
+vim.o.list = true
 vim.opt.listchars = { tab = '» ', trail = '·', nbsp = '␣' }
 
 -- Preview substitutions live, as you type!
-vim.opt.inccommand = 'split'
+vim.o.inccommand = 'split'
 
 -- Show which line your cursor is on
-vim.opt.cursorline = true
+vim.o.cursorline = true
 
 -- Minimal number of screen lines to keep above and below the cursor.
-vim.opt.scrolloff = 10
+vim.o.scrolloff = 10
 
 -- if performing an operation that would fail due to unsaved changes in the buffer (like `:q`),
 -- instead raise a dialog asking if you wish to save the current file(s)
 -- See `:help 'confirm'`
-vim.opt.confirm = true
+vim.o.confirm = true
 
 -- [[ Basic Keymaps ]]
 --  See `:help vim.keymap.set()`
@@ -226,7 +226,7 @@ vim.api.nvim_create_autocmd('TextYankPost', {
   desc = 'Highlight when yanking (copying) text',
   group = vim.api.nvim_create_augroup('kickstart-highlight-yank', { clear = true }),
   callback = function()
-    vim.highlight.on_yank()
+    vim.hl.on_yank()
   end,
 })
 
@@ -239,8 +239,11 @@ if not (vim.uv or vim.loop).fs_stat(lazypath) then
   if vim.v.shell_error ~= 0 then
     error('Error cloning lazy.nvim:\n' .. out)
   end
-end ---@diagnostic disable-next-line: undefined-field
-vim.opt.rtp:prepend(lazypath)
+end
+
+---@type vim.Option
+local rtp = vim.opt.rtp
+rtp:prepend(lazypath)
 
 -- [[ Configure and install plugins ]]
 --
@@ -255,7 +258,7 @@ vim.opt.rtp:prepend(lazypath)
 -- NOTE: Here is where you install your plugins.
 require('lazy').setup({
   -- NOTE: Plugins can be added with a link (or for a github repo: 'owner/repo' link).
-  'tpope/vim-sleuth', -- Detect tabstop and shiftwidth automatically
+  'NMAC427/guess-indent.nvim', -- Detect tabstop and shiftwidth automatically
 
   -- NOTE: Plugins can also be added by using a table,
   -- with the first argument being the link and the following
@@ -499,8 +502,8 @@ require('lazy').setup({
       -- Automatically install LSPs and related tools to stdpath for Neovim
       -- Mason must be loaded before its dependents so we need to set it up here.
       -- NOTE: `opts = {}` is the same as calling `require('mason').setup({})`
-      { 'williamboman/mason.nvim', opts = {} },
-      'williamboman/mason-lspconfig.nvim',
+      { 'mason-org/mason.nvim', opts = {} },
+      'mason-org/mason-lspconfig.nvim',
       'WhoIsSethDaniel/mason-tool-installer.nvim',
 
       -- Useful status updates for LSP.
@@ -1205,7 +1208,13 @@ vim.api.nvim_create_autocmd('TextYankPost', {
 })
 vim.api.nvim_set_hl(0, 'YankHighlight', { bg = '#44475a', fg = '#f2ece6' })
 
-vim.api.nvim_set_keymap('n', '<leader>gc', ':lua require("telescope.builtin").git_commits()<CR>', { noremap = true, silent = true, desc = 'Show Git Commits' })
+vim.api.nvim_set_keymap('n', '<leader>gC', ':lua require("telescope.builtin").git_commits()<CR>', { noremap = true, silent = true, desc = 'Show Git Commits' })
+vim.api.nvim_set_keymap(
+  'n',
+  '<leader>gc',
+  ':lua require("telescope.builtin").git_bcommits()<CR>',
+  { noremap = true, silent = true, desc = 'Show Git Buffer Commits' }
+)
 -- stylua: ignore
 vim.api.nvim_set_keymap( 'n', '<leader>gb', ':lua require("telescope.builtin").git_branches()<CR>', { noremap = true, silent = true, desc = 'Show Git Branches' })
 

--- a/init.lua
+++ b/init.lua
@@ -102,10 +102,10 @@ vim.g.have_nerd_font = true
 vim.o.number = true
 -- You can also add relative line numbers, to help with jumping.
 --  Experiment for yourself to see if you like it!
-vim.opt.relativenumber = true
+vim.o.relativenumber = true
 
 -- Enable mouse mode, can be useful for resizing splits for example!
-vim.opt.mouse = 'a'
+vim.o.mouse = 'a'
 
 -- Don't show the mode, since it's already in the status line
 vim.o.showmode = false
@@ -836,31 +836,31 @@ require('lazy').setup({
     version = '1.*',
     dependencies = {
       -- Snippet Engine
-      -- {
-      --   'L3MON4D3/LuaSnip',
-      --   version = '2.*',
-      --   build = (function()
-      --     -- Build Step is needed for regex support in snippets.
-      --     -- This step is not supported in many windows environments.
-      --     -- Remove the below condition to re-enable on windows.
-      --     if vim.fn.has 'win32' == 1 or vim.fn.executable 'make' == 0 then
-      --       return
-      --     end
-      --     return 'make install_jsregexp'
-      --   end)(),
-      --   dependencies = {
-      --     -- `friendly-snippets` contains a variety of premade snippets.
-      --     --    See the README about individual language/framework/plugin snippets:
-      --     --    https://github.com/rafamadriz/friendly-snippets
-      --     {
-      --       'rafamadriz/friendly-snippets',
-      --       config = function()
-      --         require('luasnip.loaders.from_vscode').lazy_load()
-      --       end,
-      --     },
-      --   },
-      --   opts = {},
-      -- },
+      {
+        'L3MON4D3/LuaSnip',
+        version = '2.*',
+        build = (function()
+          -- Build Step is needed for regex support in snippets.
+          -- This step is not supported in many windows environments.
+          -- Remove the below condition to re-enable on windows.
+          if vim.fn.has 'win32' == 1 or vim.fn.executable 'make' == 0 then
+            return
+          end
+          return 'make install_jsregexp'
+        end)(),
+        dependencies = {
+          -- `friendly-snippets` contains a variety of premade snippets.
+          --    See the README about individual language/framework/plugin snippets:
+          --    https://github.com/rafamadriz/friendly-snippets
+          {
+            'rafamadriz/friendly-snippets',
+            config = function()
+              require('luasnip.loaders.from_vscode').lazy_load()
+            end,
+          },
+        },
+        opts = {},
+      },
       'folke/lazydev.nvim',
     },
     --- @module 'blink.cmp'
@@ -1051,7 +1051,7 @@ require('lazy').setup({
 
 vim.cmd.colorscheme 'monet'
 vim.o.laststatus = 3
-vim.opt.cmdheight = 1
+vim.o.cmdheight = 1
 
 vim.keymap.set('n', '<leader>w', ':write<CR>', { desc = 'Save buffer' })
 vim.keymap.set('n', '<leader>Q', ':qa<CR>', { desc = 'Quit Neovim' })
@@ -1135,14 +1135,9 @@ vim.lsp.util.open_floating_preview = function(contents, syntax, opts, ...)
   return _open_floating_preview(contents, syntax, opts, ...)
 end
 
-vim.opt.foldmethod = 'indent' -- or "expr"
-vim.opt.foldenable = true -- enable folding
-vim.opt.foldlevel = 99 -- open all folds by default
-
--- Avoid No Fold found error
-vim.keymap.set('n', 'za', function()
-  vim.cmd 'silent! normal! za'
-end, { noremap = true, silent = true })
+vim.o.foldmethod = 'indent' -- or "expr"
+vim.o.foldenable = true -- enable folding
+vim.o.foldlevel = 99 -- open all folds by default
 
 -- close neo tree and copilot chat before saving session
 vim.api.nvim_create_autocmd('User', {

--- a/init.lua
+++ b/init.lua
@@ -90,6 +90,9 @@ P.S. You can delete this when you're done too. It's your config now! :)
 vim.g.mapleader = ' '
 vim.g.maplocalleader = ' '
 
+-- Ensure cargo binaries (e.g. tree-sitter CLI) are available to Neovim
+vim.env.PATH = vim.env.PATH .. ':' .. vim.env.HOME .. '/.cargo/bin'
+
 -- Set to true if you have a Nerd Font installed and selected in the terminal
 vim.g.have_nerd_font = true
 
@@ -168,7 +171,18 @@ vim.o.confirm = true
 --  See `:help hlsearch`
 vim.keymap.set('n', '<Esc>', '<cmd>nohlsearch<CR>')
 
--- Diagnostic keymaps
+-- Diagnostic Config & Keymaps
+-- See :help vim.diagnostic.Opts
+vim.diagnostic.config {
+  update_in_insert = false,
+  severity_sort = true,
+  float = { border = 'rounded', source = 'if_many' },
+  underline = { severity = { min = vim.diagnostic.severity.WARN } },
+  virtual_text = true,
+  virtual_lines = false,
+  jump = { float = true },
+}
+
 vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagnostic [Q]uickfix list' })
 
 -- Exit terminal mode in the builtin terminal with a shortcut that is a bit easier
@@ -316,48 +330,14 @@ require('lazy').setup({
       -- delay between pressing a key and opening which-key (milliseconds)
       -- this setting is independent of vim.opt.timeoutlen
       delay = 0,
-      icons = {
-        -- set icon mappings to true if you have a Nerd Font
-        mappings = vim.g.have_nerd_font,
-        -- If you are using a Nerd Font: set icons.keys to an empty table which will use the
-        -- default which-key.nvim defined Nerd Font icons, otherwise define a string table
-        keys = vim.g.have_nerd_font and {} or {
-          Up = '<Up> ',
-          Down = '<Down> ',
-          Left = '<Left> ',
-          Right = '<Right> ',
-          C = '<C-…> ',
-          M = '<M-…> ',
-          D = '<D-…> ',
-          S = '<S-…> ',
-          CR = '<CR> ',
-          Esc = '<Esc> ',
-          ScrollWheelDown = '<ScrollWheelDown> ',
-          ScrollWheelUp = '<ScrollWheelUp> ',
-          NL = '<NL> ',
-          BS = '<BS> ',
-          Space = '<Space> ',
-          Tab = '<Tab> ',
-          F1 = '<F1>',
-          F2 = '<F2>',
-          F3 = '<F3>',
-          F4 = '<F4>',
-          F5 = '<F5>',
-          F6 = '<F6>',
-          F7 = '<F7>',
-          F8 = '<F8>',
-          F9 = '<F9>',
-          F10 = '<F10>',
-          F11 = '<F11>',
-          F12 = '<F12>',
-        },
-      },
+      icons = { mappings = vim.g.have_nerd_font },
 
       -- Document existing key chains
       spec = {
-        { '<leader>s', group = '[S]earch' },
+        { '<leader>s', group = '[S]earch', mode = { 'n', 'v' } },
         { '<leader>t', group = '[T]oggle' },
         { '<leader>h', group = 'Git [H]unk', mode = { 'n', 'v' } },
+        { 'gr', group = 'LSP Actions', mode = { 'n' } },
       },
     },
   },
@@ -484,33 +464,25 @@ require('lazy').setup({
 
   -- LSP Plugins
   {
-    -- `lazydev` configures Lua LSP for your Neovim config, runtime and plugins
-    -- used for completion, annotations and signatures of Neovim apis
-    'folke/lazydev.nvim',
-    ft = 'lua',
-    opts = {
-      library = {
-        -- Load luvit types when the `vim.uv` word is found
-        { path = '${3rd}/luv/library', words = { 'vim%.uv' } },
-      },
-    },
-  },
-  {
     -- Main LSP Configuration
     'neovim/nvim-lspconfig',
     dependencies = {
       -- Automatically install LSPs and related tools to stdpath for Neovim
       -- Mason must be loaded before its dependents so we need to set it up here.
       -- NOTE: `opts = {}` is the same as calling `require('mason').setup({})`
-      { 'mason-org/mason.nvim', opts = {} },
+      {
+        'mason-org/mason.nvim',
+        ---@module 'mason.settings'
+        ---@type MasonSettings
+        ---@diagnostic disable-next-line: missing-fields
+        opts = {},
+      },
+      -- Maps LSP server names between nvim-lspconfig and Mason package names.
       'mason-org/mason-lspconfig.nvim',
       'WhoIsSethDaniel/mason-tool-installer.nvim',
 
       -- Useful status updates for LSP.
       { 'j-hui/fidget.nvim', opts = {} },
-
-      -- Allows extra capabilities provided by blink.cmp
-      'saghen/blink.cmp',
     },
     config = function()
       -- Brief aside: **What is LSP?**
@@ -598,26 +570,13 @@ require('lazy').setup({
           --  the definition of its *type*, not where it was *defined*.
           map('grt', require('telescope.builtin').lsp_type_definitions, '[G]oto [T]ype Definition')
 
-          -- This function resolves a difference between neovim nightly (version 0.11) and stable (version 0.10)
-          ---@param client vim.lsp.Client
-          ---@param method vim.lsp.protocol.Method
-          ---@param bufnr? integer some lsp support methods only in specific files
-          ---@return boolean
-          local function client_supports_method(client, method, bufnr)
-            if vim.fn.has 'nvim-0.11' == 1 then
-              return client:supports_method(method, bufnr)
-            else
-              return client.supports_method(method, { bufnr = bufnr })
-            end
-          end
-
           -- The following two autocommands are used to highlight references of the
           -- word under your cursor when your cursor rests there for a little while.
           --    See `:help CursorHold` for information about when this is executed
           --
           -- When you move your cursor, the highlights will be cleared (the second autocommand).
           local client = vim.lsp.get_client_by_id(event.data.client_id)
-          if client and client_supports_method(client, vim.lsp.protocol.Methods.textDocument_documentHighlight, event.buf) then
+          if client and client:supports_method('textDocument/documentHighlight', event.buf) then
             local highlight_augroup = vim.api.nvim_create_augroup('kickstart-lsp-highlight', { clear = false })
             vim.api.nvim_create_autocmd({ 'CursorHold', 'CursorHoldI' }, {
               buffer = event.buf,
@@ -644,7 +603,7 @@ require('lazy').setup({
           -- code, if the language server you are using supports them
           --
           -- This may be unwanted, since they displace some of your code
-          if client and client_supports_method(client, vim.lsp.protocol.Methods.textDocument_inlayHint, event.buf) then
+          if client and client:supports_method('textDocument/inlayHint', event.buf) then
             map('<leader>th', function()
               vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled { bufnr = event.buf })
             end, '[T]oggle Inlay [H]ints')
@@ -652,75 +611,52 @@ require('lazy').setup({
         end,
       })
 
-      -- Diagnostic Config
-      -- See :help vim.diagnostic.Opts
-      vim.diagnostic.config {
-        severity_sort = true,
-        float = { border = 'rounded', source = 'if_many' },
-        underline = { severity = vim.diagnostic.severity.ERROR },
-        signs = vim.g.have_nerd_font and {
-          text = {
-            [vim.diagnostic.severity.ERROR] = '󰅚 ',
-            [vim.diagnostic.severity.WARN] = '󰀪 ',
-            [vim.diagnostic.severity.INFO] = '󰋽 ',
-            [vim.diagnostic.severity.HINT] = '󰌶 ',
-          },
-        } or {},
-        virtual_text = {
-          source = 'if_many',
-          spacing = 2,
-          format = function(diagnostic)
-            local diagnostic_message = {
-              [vim.diagnostic.severity.ERROR] = diagnostic.message,
-              [vim.diagnostic.severity.WARN] = diagnostic.message,
-              [vim.diagnostic.severity.INFO] = diagnostic.message,
-              [vim.diagnostic.severity.HINT] = diagnostic.message,
-            }
-            return diagnostic_message[diagnostic.severity]
-          end,
-        },
-      }
-
-      -- LSP servers and clients are able to communicate to each other what features they support.
-      --  By default, Neovim doesn't support everything that is in the LSP specification.
-      --  When you add blink.cmp, luasnip, etc. Neovim now has *more* capabilities.
-      --  So, we create new capabilities with blink.cmp, and then broadcast that to the servers.
-      local capabilities = require('blink.cmp').get_lsp_capabilities()
-
       -- Enable the following language servers
       --  Feel free to add/remove any LSPs that you want here. They will automatically be installed.
-      --
-      --  Add any additional override configuration in the following tables. Available keys are:
-      --  - cmd (table): Override the default command used to start the server
-      --  - filetypes (table): Override the default list of associated filetypes for the server
-      --  - capabilities (table): Override fields in capabilities. Can be used to disable certain LSP features.
-      --  - settings (table): Override the default settings passed when initializing the server.
-      --        For example, to see the options for `lua_ls`, you could go to: https://luals.github.io/wiki/settings/
+      --  See `:help lsp-config` for information about keys and how to configure
+      ---@type table<string, vim.lsp.Config>
       local servers = {
         -- clangd = {},
         -- gopls = {},
         -- pyright = {},
         -- rust_analyzer = {},
-        -- ... etc. See `:help lspconfig-all` for a list of all the pre-configured LSPs
         --
         -- Some languages (like typescript) have entire language plugins that can be useful:
         --    https://github.com/pmizio/typescript-tools.nvim
         --
         -- But for many setups, the LSP (`ts_ls`) will work just fine
         -- ts_ls = {},
-        --
 
+        stylua = {}, -- Used to format Lua code
+
+        -- Special Lua Config, as recommended by neovim help docs
         lua_ls = {
-          -- cmd = { ... },
-          -- filetypes = { ... },
-          -- capabilities = {},
+          on_init = function(client)
+            client.server_capabilities.documentFormattingProvider = false -- Disable formatting (formatting is done by stylua)
+
+            if client.workspace_folders then
+              local path = client.workspace_folders[1].name
+              if path ~= vim.fn.stdpath 'config' and (vim.uv.fs_stat(path .. '/.luarc.json') or vim.uv.fs_stat(path .. '/.luarc.jsonc')) then return end
+            end
+
+            client.config.settings.Lua = vim.tbl_deep_extend('force', client.config.settings.Lua, {
+              runtime = {
+                version = 'LuaJIT',
+                path = { 'lua/?.lua', 'lua/?/init.lua' },
+              },
+              workspace = {
+                checkThirdParty = false,
+                library = vim.tbl_extend('force', vim.api.nvim_get_runtime_file('', true), {
+                  '${3rd}/luv/library',
+                  '${3rd}/busted/library',
+                }),
+              },
+            })
+          end,
+          ---@type lspconfig.settings.lua_ls
           settings = {
             Lua = {
-              completion = {
-                callSnippet = 'Replace',
-              },
-              -- You can toggle below to ignore Lua_LS's noisy `missing-fields` warnings
-              -- diagnostics = { disable = { 'missing-fields' } },
+              format = { enable = false }, -- Disable formatting (formatting is done by stylua)
             },
           },
         },
@@ -787,38 +723,21 @@ require('lazy').setup({
       --    :Mason
       --
       -- You can press `g?` for help in this menu.
-      --
-      -- `mason` had to be setup earlier: to configure its options see the
-      -- `dependencies` table for `nvim-lspconfig` above.
-      --
-      -- You can add other tools here that you want Mason to install
-      -- for you, so that they are available from within Neovim.
       local ensure_installed = vim.tbl_keys(servers or {})
       vim.list_extend(ensure_installed, {
-        'stylua',
         'eslint',
         'prettierd',
         'black',
         'isort',
-        'gofumpt',
-        'goimports',
+        -- 'gofumpt',
+        -- 'goimports',
       })
       require('mason-tool-installer').setup { ensure_installed = ensure_installed }
 
-      require('mason-lspconfig').setup {
-        ensure_installed = {}, -- explicitly set to an empty table (Kickstart populates installs via mason-tool-installer)
-        automatic_installation = false,
-        handlers = {
-          function(server_name)
-            local server = servers[server_name] or {}
-            -- This handles overriding only values explicitly passed
-            -- by the server configuration above. Useful when disabling
-            -- certain features of an LSP (for example, turning off formatting for ts_ls)
-            server.capabilities = vim.tbl_deep_extend('force', {}, capabilities, server.capabilities or {})
-            require('lspconfig')[server_name].setup(server)
-          end,
-        },
-      }
+      for name, server in pairs(servers) do
+        vim.lsp.config(name, server)
+        vim.lsp.enable(name)
+      end
     end,
   },
 
@@ -830,19 +749,26 @@ require('lazy').setup({
     opts = {
       notify_on_error = false,
       format_on_save = function(bufnr)
-        -- Disable "format_on_save lsp_fallback" for languages that don't
-        -- have a well standardized coding style. You can add additional
-        -- languages here or re-enable it for the disabled ones.
-        local disable_filetypes = { c = true, cpp = true }
-        if disable_filetypes[vim.bo[bufnr].filetype] then
-          return nil
+        -- You can specify filetypes to autoformat on save here:
+        local enabled_filetypes = {
+          lua = true,
+          python = true,
+          javascript = true,
+          typescript = true,
+          html = true,
+          htmlangular = true,
+          scss = true,
+          json = true,
+        }
+        if enabled_filetypes[vim.bo[bufnr].filetype] then
+          return { timeout_ms = 500 }
         else
-          return {
-            timeout_ms = 500,
-            lsp_format = 'fallback',
-          }
+          return nil
         end
       end,
+      default_format_opts = {
+        lsp_format = 'fallback',
+      },
       formatters_by_ft = {
         lua = { 'stylua' },
         python = { 'isort', 'black' },
@@ -888,10 +814,9 @@ require('lazy').setup({
         },
         opts = {},
       },
-      'folke/lazydev.nvim',
     },
-    --- @module 'blink.cmp'
-    --- @type blink.cmp.Config
+    ---@module 'blink.cmp'
+    ---@type blink.cmp.Config
     opts = {
       keymap = {
         -- 'default' (recommended) for mappings similar to built-in completions
@@ -939,13 +864,10 @@ require('lazy').setup({
       },
 
       sources = {
-        default = { 'lsp', 'path', 'snippets', 'lazydev' },
-        providers = {
-          lazydev = { module = 'lazydev.integrations.blink', score_offset = 100 },
-        },
+        default = { 'lsp', 'path', 'snippets' },
       },
 
-      -- snippets = { preset = 'luasnip' },
+      snippets = { preset = 'luasnip' },
 
       -- Blink.cmp includes an optional, recommended rust fuzzy matcher,
       -- which automatically downloads a prebuilt binary when enabled.
@@ -962,15 +884,22 @@ require('lazy').setup({
   },
 
   { -- Collection of various small independent plugins/modules
-    'echasnovski/mini.nvim',
+    'nvim-mini/mini.nvim',
     config = function()
       -- Better Around/Inside textobjects
       --
       -- Examples:
       --  - va)  - [V]isually select [A]round [)]paren
-      --  - yinq - [Y]ank [I]nside [N]ext [Q]uote
+      --  - yiiq - [Y]ank [I]nside [I]+1 [Q]uote
       --  - ci'  - [C]hange [I]nside [']quote
-      require('mini.ai').setup { n_lines = 500 }
+      require('mini.ai').setup {
+        -- NOTE: Avoid conflicts with the built-in incremental selection mappings on Neovim>=0.12 (see `:help treesitter-incremental-selection`)
+        mappings = {
+          around_next = 'aa',
+          inside_next = 'ii',
+        },
+        n_lines = 500,
+      }
 
       -- Add/delete/replace surroundings (brackets, quotes, etc.)
       --
@@ -980,45 +909,58 @@ require('lazy').setup({
       require('mini.surround').setup()
 
       -- ... and there is more!
-      --  Check out: https://github.com/echasnovski/mini.nvim
+      --  Check out: https://github.com/nvim-mini/mini.nvim
     end,
   },
   { -- Highlight, edit, and navigate code
     'nvim-treesitter/nvim-treesitter',
+    lazy = false,
     build = ':TSUpdate',
-    main = 'nvim-treesitter.configs', -- Sets main module to use for opts
-    -- [[ Configure Treesitter ]] See `:help nvim-treesitter`
-    opts = {
-      ensure_installed = {
-        'bash',
-        'c',
-        'diff',
-        'html',
-        'css',
-        'lua',
-        'luadoc',
-        'markdown',
-        'markdown_inline',
-        'query',
-        'vim',
-        'vimdoc',
-        'json',
-        'typescript',
-        'javascript',
-        'python',
-        'toml',
-      },
-      -- Autoinstall languages that are not installed
-      auto_install = true,
-      highlight = {
-        enable = true,
-        -- Some languages depend on vim's regex highlighting system (such as Ruby) for indent rules.
-        --  If you are experiencing weird indenting issues, add the language to
-        --  the list of additional_vim_regex_highlighting and disabled languages for indent.
-        additional_vim_regex_highlighting = { 'ruby' },
-      },
-      indent = { enable = true, disable = { 'ruby' } },
-    },
+    branch = 'main',
+    -- [[ Configure Treesitter ]] See `:help nvim-treesitter-intro`
+    config = function()
+      -- ensure basic parsers are installed
+      local parsers = {
+        'bash', 'c', 'diff', 'html', 'css', 'lua', 'luadoc',
+        'markdown', 'markdown_inline', 'query', 'vim', 'vimdoc',
+        'json', 'typescript', 'javascript', 'python', 'toml',
+      }
+      require('nvim-treesitter').install(parsers)
+
+      ---@param buf integer
+      ---@param language string
+      local function treesitter_try_attach(buf, language)
+        -- check if parser exists and load it
+        if not vim.treesitter.language.add(language) then return end
+        -- enables syntax highlighting and other treesitter features
+        vim.treesitter.start(buf, language)
+
+        -- check if treesitter indentation is available for this language, and if so enable it
+        -- in case there is no indent query, the indentexpr will fallback to vim's built-in one
+        local has_indent_query = vim.treesitter.query.get(language, 'indents') ~= nil
+        if has_indent_query then vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()" end
+      end
+
+      local available_parsers = require('nvim-treesitter').get_available()
+      vim.api.nvim_create_autocmd('FileType', {
+        callback = function(args)
+          local buf, filetype = args.buf, args.match
+
+          local language = vim.treesitter.language.get_lang(filetype)
+          if not language then return end
+
+          local installed_parsers = require('nvim-treesitter').get_installed 'parsers'
+
+          if vim.tbl_contains(installed_parsers, language) then
+            treesitter_try_attach(buf, language)
+          elseif vim.tbl_contains(available_parsers, language) then
+            require('nvim-treesitter').install(language):await(function() treesitter_try_attach(buf, language) end)
+          else
+            treesitter_try_attach(buf, language)
+          end
+        end,
+      })
+    end,
     -- There are additional nvim-treesitter modules that you can use to interact
     -- with nvim-treesitter. You should go explore a few and see what interests you:
     --

--- a/init.lua
+++ b/init.lua
@@ -271,6 +271,9 @@ rtp:prepend(lazypath)
 --
 -- NOTE: Here is where you install your plugins.
 require('lazy').setup({
+  -- Override community/rocks spec for plenary — it has no 'main' branch, only 'master'
+  { 'nvim-lua/plenary.nvim', branch = 'master', version = false },
+
   -- NOTE: Plugins can be added with a link (or for a github repo: 'owner/repo' link).
   -- 'NMAC427/guess-indent.nvim', -- Detect tabstop and shiftwidth automatically
 
@@ -353,10 +356,9 @@ require('lazy').setup({
     'nvim-telescope/telescope.nvim',
     event = 'VimEnter',
     dependencies = {
-      'nvim-lua/plenary.nvim',
+      { 'nvim-lua/plenary.nvim', branch = 'master' },
       { -- If encountering errors, see telescope-fzf-native README for installation instructions
         'nvim-telescope/telescope-fzf-native.nvim',
-
         -- `build` is used to run some command when the plugin is installed/updated.
         -- This is only run then, not every time Neovim starts up.
         build = 'make',

--- a/init.lua
+++ b/init.lua
@@ -1257,3 +1257,5 @@ local function quick_chat(selection_type)
 end
 
 vim.keymap.set('v', '<leader>p', quick_chat 'visual', { desc = 'Quick Chat' })
+
+require 'custom.plugins.global_replace'

--- a/lua/custom/plugins/copilot.lua
+++ b/lua/custom/plugins/copilot.lua
@@ -29,7 +29,7 @@ return {
     event = 'BufReadPost',
     dependencies = {
       { 'github/copilot.vim' }, -- or zbirenbaum/copilot.lua
-      { 'nvim-lua/plenary.nvim', branch = 'master' }, -- for curl, log and async functions
+      { 'nvim-lua/plenary.nvim' }, -- for curl, log and async functions
     },
     build = 'make tiktoken', -- Only on MacOS or Linux
     opts = {

--- a/lua/custom/plugins/global_replace.lua
+++ b/lua/custom/plugins/global_replace.lua
@@ -275,7 +275,8 @@ local function execute_replacement(results, find_text, replace_text)
             while true do
               local lower_line = new_line:lower()
               local lower_find = find_text:lower()
-              local pos = lower_line:find(vim.pesc(lower_find), start_pos, true)
+              -- Use plain text search (no patterns) - don't need vim.pesc here
+              local pos = lower_line:find(lower_find, start_pos, true)
 
               if not pos then break end
 

--- a/lua/custom/plugins/global_replace.lua
+++ b/lua/custom/plugins/global_replace.lua
@@ -1,102 +1,477 @@
 local M = {}
 
--- Utility: simple centered floating window
-local function open_centered_window(lines, title, height)
-  local buf = vim.api.nvim_create_buf(false, true)
-  local width = 60
-  height = height or (#lines + 2)
-  local ui = vim.api.nvim_list_uis()[1]
+-- Configuration
+local config = {
+  case_sensitive = false,
+  regex_mode = false,
+  exclude_patterns = { '*.git/*', '*.node_modules/*', '*.log' },
+  max_preview_lines = 50,
+}
 
-  local opts = {
-    relative = 'editor',
-    width = width,
-    height = math.min(height, ui.height - 4),
-    col = (ui.width - width) / 2,
-    row = (ui.height - height) / 2,
-    border = 'rounded',
-    style = 'minimal',
-    title = title or 'Popup',
-  }
 
-  local win = vim.api.nvim_open_win(buf, true, opts)
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-  return buf, win
+-- Utility: validate search pattern
+local function validate_pattern(pattern)
+  if not pattern or pattern == '' then
+    return false, 'Search pattern cannot be empty'
+  end
+
+  -- Test if pattern is valid regex when in regex mode
+  if config.regex_mode then
+    local ok, err = pcall(vim.regex, pattern)
+    if not ok then
+      return false, 'Invalid regex pattern: ' .. tostring(err)
+    end
+  end
+
+  return true, nil
 end
 
--- Main function
+-- Utility: escape pattern for different contexts
+local function escape_pattern(pattern, context)
+  if context == 'grep' then
+    -- Escape for shell command
+    return vim.fn.shellescape(pattern)
+  elseif context == 'vim_substitute' then
+    -- Escape for vim substitute command
+    if config.regex_mode then
+      return pattern
+    else
+      -- Escape special vim regex characters for literal search
+      local escaped = pattern:gsub('[.*^$\\[\\]~]', '\\%0')
+      return escaped
+    end
+  end
+  return pattern
+end
+
+-- Internal function to run grep/ripgrep search
+local function run_grep(find)
+  local valid, err = validate_pattern(find)
+  if not valid then
+    vim.notify('Error: ' .. err, vim.log.levels.ERROR)
+    return {}
+  end
+
+  local results
+
+  if vim.fn.executable('rg') == 1 then
+    -- Use ripgrep with proper argument handling
+    local rg_args = {
+      'rg',
+      '--no-heading',
+      '--line-number',
+      '--color=never'
+    }
+
+    if not config.case_sensitive then
+      table.insert(rg_args, '--ignore-case')
+    end
+
+    if not config.regex_mode then
+      table.insert(rg_args, '--fixed-strings')
+    end
+
+    -- Add exclude patterns for ripgrep
+    for _, pattern in ipairs(config.exclude_patterns) do
+      table.insert(rg_args, '--glob')
+      table.insert(rg_args, '!' .. pattern)
+    end
+
+    -- Add the search pattern directly (no shell escaping needed for vim.system)
+    table.insert(rg_args, find)
+    table.insert(rg_args, '.')
+
+    -- Use vim.system (Neovim 0.10+) or fallback to systemlist with proper escaping
+    if vim.system then
+      -- Debug: show the actual command being run
+      vim.notify('Debug: Running rg with args: ' .. vim.inspect(rg_args), vim.log.levels.INFO)
+
+      local result = vim.system(rg_args, { text = true }):wait()
+      results = result.stdout and vim.split(result.stdout, '\n') or {}
+
+      -- Remove empty lines
+      local filtered_results = {}
+      for _, line in ipairs(results) do
+        if line ~= '' then
+          table.insert(filtered_results, line)
+        end
+      end
+      results = filtered_results
+    else
+      -- Fallback for older Neovim versions - need shell escaping here
+      local escaped_find = escape_pattern(find, 'grep')
+      local cmd = 'rg --no-heading --line-number --color=never'
+
+      if not config.case_sensitive then
+        cmd = cmd .. ' --ignore-case'
+      end
+
+      if not config.regex_mode then
+        cmd = cmd .. ' --fixed-strings'
+      end
+
+      -- Skip glob patterns for now to avoid shell issues
+      cmd = cmd .. ' ' .. escaped_find .. ' .'
+
+      vim.notify('Debug: Running command: ' .. cmd, vim.log.levels.INFO)
+      results = vim.fn.systemlist(cmd)
+    end
+  else
+    -- Use regular grep - build command differently
+    local escaped_find = escape_pattern(find, 'grep')
+    local grep_cmd = 'grep -RIn'
+
+    if not config.case_sensitive then
+      grep_cmd = grep_cmd .. 'i'
+    end
+
+    if not config.regex_mode then
+      grep_cmd = grep_cmd .. ' -F'
+    end
+
+    local cmd = string.format('%s %s . 2>/dev/null', grep_cmd, escaped_find)
+
+    -- Debug: show the actual command being run
+    vim.notify('Debug: Running command: ' .. cmd, vim.log.levels.INFO)
+
+    results = vim.fn.systemlist(cmd)
+  end
+
+  -- Filter out excluded patterns for grep (rg handles this natively)
+  if vim.fn.executable('rg') ~= 1 then
+    local filtered = {}
+    for _, line in ipairs(results) do
+      local should_include = true
+      local file_path = line:match('^([^:]+):')
+
+      if file_path then
+        for _, pattern in ipairs(config.exclude_patterns) do
+          local glob_pattern = pattern:gsub('%*', '.*'):gsub('?', '.')
+          if file_path:match(glob_pattern) then
+            should_include = false
+            break
+          end
+        end
+      end
+
+      if should_include then
+        table.insert(filtered, line)
+      end
+    end
+    results = filtered
+  end
+
+  return results
+end
+
+-- Internal function to execute find and replace directly
+local function execute_replacement(results, find_text, replace_text)
+  if #results == 0 then
+    vim.notify('❌ No matches found for: ' .. find_text, vim.log.levels.WARN)
+    return
+  end
+
+  -- Debug: show first few grep results
+  vim.notify('Debug: First few grep results:', vim.log.levels.INFO)
+  for i = 1, math.min(3, #results) do
+    vim.notify('  ' .. results[i], vim.log.levels.INFO)
+  end
+
+  -- Parse results to get unique file list - be more careful with parsing
+  local file_set = {}
+  local match_count = 0
+
+  for _, line in ipairs(results) do
+    -- Handle both rg and grep output formats
+    local file = line:match('^([^:]+):')
+    if file and file ~= '' then
+      -- Clean up the file path
+      file = file:gsub('^%s+', ''):gsub('%s+$', '') -- trim whitspace
+
+      -- Skip if it looks like a shell command or invalid path
+      if not file:match('^[a-zA-Z]') and not file:match('^[/.~]') then
+        vim.notify('Skipping invalid file path: ' .. file, vim.log.levels.WARN)
+      else
+        file_set[file] = true
+        match_count = match_count + 1
+      end
+    end
+  end
+
+  local file_list = {}
+  for file, _ in pairs(file_set) do
+    -- Verify file exists before adding to list
+    if vim.fn.filereadable(file) == 1 then
+      table.insert(file_list, file)
+    else
+      vim.notify('File not readable: ' .. file, vim.log.levels.WARN)
+    end
+  end
+  table.sort(file_list)
+
+  local file_count = #file_list
+
+  if file_count == 0 then
+    vim.notify('❌ No readable files found with matches', vim.log.levels.ERROR)
+    return
+  end
+
+  -- Show what we found
+  vim.notify(string.format('🔍 Found %d matches in %d files - processing...', match_count, file_count), vim.log.levels.INFO)
+
+  -- Perform the replacement
+  local files_changed = 0
+  local errors = {}
+
+  for i, file in ipairs(file_list) do
+    local success, err = pcall(function()
+      if vim.fn.filereadable(file) ~= 1 then
+        table.insert(errors, file .. ': File not readable')
+        return
+      end
+
+      -- Read file content directly
+      local lines = vim.fn.readfile(file)
+      if not lines then
+        table.insert(errors, file .. ': Could not read file')
+        return
+      end
+
+      local modified = false
+      local new_lines = {}
+
+      -- Process each line
+      for _, line in ipairs(lines) do
+        local new_line = line
+        local original_line = line
+
+        if config.regex_mode then
+          -- Use regex replacement
+          if config.case_sensitive then
+            new_line = line:gsub(find_text, replace_text)
+          else
+            -- For case-insensitive regex, we need a different approach
+            -- Create a case-insensitive pattern manually
+            local ci_pattern = ''
+            for i = 1, #find_text do
+              local char = find_text:sub(i, i)
+              if char:match('%a') then
+                ci_pattern = ci_pattern .. '[' .. char:lower() .. char:upper() .. ']'
+              else
+                ci_pattern = ci_pattern .. vim.pesc(char)
+              end
+            end
+            new_line = line:gsub(ci_pattern, replace_text)
+          end
+        else
+          -- Literal replacement
+          if config.case_sensitive then
+            new_line = line:gsub(vim.pesc(find_text), replace_text)
+          else
+            -- Case-insensitive literal replacement - simpler approach
+            new_line = line
+            local start_pos = 1
+
+            while true do
+              local lower_line = new_line:lower()
+              local lower_find = find_text:lower()
+              local pos = lower_line:find(vim.pesc(lower_find), start_pos, true)
+
+              if not pos then break end
+
+              local before = new_line:sub(1, pos - 1)
+              local after = new_line:sub(pos + #find_text)
+              new_line = before .. replace_text .. after
+              start_pos = pos + #replace_text
+            end
+          end
+        end
+
+        if new_line ~= original_line then
+          modified = true
+        end
+        table.insert(new_lines, new_line)
+      end
+
+      -- Write file if modified
+      if modified then
+        local write_success = vim.fn.writefile(new_lines, file)
+        if write_success == 0 then
+          files_changed = files_changed + 1
+        else
+          table.insert(errors, file .. ': Could not write file')
+        end
+      end
+    end)
+
+    if not success then
+      table.insert(errors, file .. ': ' .. tostring(err))
+    end
+  end
+
+  -- Report results
+  if #errors > 0 then
+    vim.notify('⚠️  Errors in some files:', vim.log.levels.WARN)
+    for _, error_msg in ipairs(errors) do
+      vim.notify('   ' .. error_msg, vim.log.levels.WARN)
+    end
+  end
+
+  if files_changed > 0 then
+    vim.notify(string.format('✅ Replaced "%s" → "%s" in %d files', find_text, replace_text, files_changed), vim.log.levels.INFO)
+
+    -- Show file list if not too many
+    if files_changed <= 8 then
+      local changed_files = {}
+      for _, file in ipairs(file_list) do
+        table.insert(changed_files, vim.fn.fnamemodify(file, ':t'))
+      end
+      vim.notify('📝 ' .. table.concat(changed_files, ', '), vim.log.levels.INFO)
+    end
+  else
+    vim.notify('⚠️  No files were modified', vim.log.levels.WARN)
+  end
+end
+
+-- Main function using vim's command line for input
 function M.open_find_replace_popup()
-  local buf = vim.api.nvim_create_buf(false, true)
-  local width, height = 40, 5
-  local ui = vim.api.nvim_list_uis()[1]
-  local opts = {
-    relative = 'editor',
-    width = width,
-    height = height,
-    col = (ui.width - width) / 2,
-    row = (ui.height - height) / 2,
-    border = 'rounded',
-    style = 'minimal',
-    title = ' Global Find & Replace ',
-  }
+  -- Show current configuration
+  local case_indicator = config.case_sensitive and '[Case-sensitive]' or '[Ignore-case]'
+  local regex_indicator = config.regex_mode and '[Regex]' or '[Literal]'
+  vim.notify(string.format('🔍 Find & Replace Mode: %s %s', case_indicator, regex_indicator), vim.log.levels.INFO)
 
-  vim.api.nvim_open_win(buf, true, opts)
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
-    'Find: ',
-    'Replace: ',
-    '',
-    '(Press <Enter> to search, <Esc> to cancel)',
-  })
-
-  local data = { find = '', replace = '', step = 1 }
-  vim.api.nvim_win_set_cursor(0, { 1, 7 }) -- Start after "Find: "
-
-  local function close_popup()
-    vim.api.nvim_win_close(0, true)
-  end
-
-  local function run_grep(find)
-    local cmd = vim.fn.executable('rg') == 1
-      and string.format('rg --no-heading --line-number "%s"', find)
-      or string.format('grep -RIn "%s" .', find)
-    return vim.fn.systemlist(cmd)
-  end
-
-  local function show_grep_results(results)
-    if #results == 0 then
-      open_centered_window({ 'No matches found.' }, 'Results', 3)
+  -- Use vim.ui.input for search term
+  vim.ui.input({
+    prompt = '🔍 Find: ',
+    default = '',
+  }, function(find_text)
+    if not find_text or find_text == '' then
+      vim.notify('❌ Search cancelled', vim.log.levels.WARN)
       return
     end
 
-    local preview_buf, preview_win = open_centered_window(results, 'Affected Files', 20)
-    vim.api.nvim_buf_set_option(preview_buf, 'modifiable', false)
-
-    vim.keymap.set('n', '<Esc>', function()
-      vim.api.nvim_win_close(preview_win, true)
-    end, { buffer = preview_buf })
-
-    vim.keymap.set('n', '<CR>', function()
-      vim.api.nvim_win_close(preview_win, true)
-      vim.cmd('args **/*')
-      vim.cmd('argdo %s/' .. vim.fn.escape(data.find, '/') .. '/' .. vim.fn.escape(data.replace, '/') .. '/g | update')
-      print("Replaced all occurrences of '" .. data.find .. "' with '" .. data.replace .. "'.")
-    end, { buffer = preview_buf })
-  end
-
-  vim.keymap.set('i', '<CR>', function()
-    if data.step == 1 then
-      data.find = vim.api.nvim_get_current_line():sub(7)
-      data.step = 2
-      vim.api.nvim_win_set_cursor(0, { 2, 10 }) -- move to Replace line
-    else
-      data.replace = vim.api.nvim_get_current_line():sub(10)
-      close_popup()
-      local results = run_grep(data.find)
-      show_grep_results(results)
+    -- Validate the search pattern
+    local valid, err = validate_pattern(find_text)
+    if not valid then
+      vim.notify('❌ ' .. err, vim.log.levels.ERROR)
+      return
     end
-  end, { buffer = buf })
 
-  vim.keymap.set('i', '<Esc>', close_popup, { buffer = buf })
+    -- Use vim.ui.input for replacement term
+    vim.ui.input({
+      prompt = '🔄 Replace with: ',
+      default = '',
+    }, function(replace_text)
+      if replace_text == nil then -- User cancelled
+        vim.notify('❌ Replace cancelled', vim.log.levels.WARN)
+        return
+      end
+
+      -- replace_text can be empty string for deletion
+      M.execute_find_replace(find_text, replace_text)
+    end)
+  end)
 end
 
-vim.api.nvim_create_user_command('GlobalFindReplace', M.open_find_replace_popup, {})
+-- Separate function to execute the find and replace
+function M.execute_find_replace(find_text, replace_text)
+  vim.notify('🔍 Searching for matches...', vim.log.levels.INFO)
+
+  -- Debug: Show search configuration
+  vim.notify(string.format('Debug: Searching for "%s" (case: %s, regex: %s)',
+    find_text,
+    config.case_sensitive and 'sensitive' or 'ignore',
+    config.regex_mode and 'on' or 'off'), vim.log.levels.INFO)
+
+  local results = run_grep(find_text)
+
+  -- Debug: Show total results count
+  vim.notify(string.format('Debug: Grep returned %d lines', #results), vim.log.levels.INFO)
+
+  execute_replacement(results, find_text, replace_text)
+end
+
+-- Toggle configuration options
+function M.toggle_case_sensitive()
+  config.case_sensitive = not config.case_sensitive
+  vim.notify((config.case_sensitive and '🔤 Case sensitive ON' or '🔤 Case sensitive OFF'), vim.log.levels.INFO)
+end
+
+function M.toggle_regex_mode()
+  config.regex_mode = not config.regex_mode
+  vim.notify((config.regex_mode and '📝 Regex mode ON' or '📝 Literal mode ON'), vim.log.levels.INFO)
+end
+
+-- Configuration function
+function M.setup(opts)
+  opts = opts or {}
+  config.case_sensitive = opts.case_sensitive or config.case_sensitive
+  config.regex_mode = opts.regex_mode or config.regex_mode
+  config.exclude_patterns = opts.exclude_patterns or config.exclude_patterns
+  config.max_preview_lines = opts.max_preview_lines or config.max_preview_lines
+end
+
+-- Export config for external access
+function M.get_config()
+  return vim.deepcopy(config)
+end
+
+function M.set_config(new_config)
+  config = vim.tbl_deep_extend('force', config, new_config)
+end
+
+-- Commands
+vim.api.nvim_create_user_command('GlobalFindReplace', function(opts)
+  -- Parse arguments for direct find/replace
+  local args = vim.split(opts.args, '%s+')
+  if #args >= 2 then
+    local find_text = args[1]
+    local replace_text = args[2]
+    M.execute_find_replace(find_text, replace_text)
+  else
+    M.open_find_replace_popup()
+  end
+end, {
+  desc = 'Global find and replace. Usage: :GlobalFindReplace [find_text] [replace_text]',
+  nargs = '*',
+})
+
+vim.api.nvim_create_user_command('GFR', function(opts)
+  local args = vim.split(opts.args, '%s+')
+  if #args >= 2 then
+    local find_text = args[1]
+    local replace_text = args[2]
+    M.execute_find_replace(find_text, replace_text)
+  else
+    M.open_find_replace_popup()
+  end
+end, {
+  desc = 'Short alias for GlobalFindReplace',
+  nargs = '*',
+})
+
+-- Configuration commands
+vim.api.nvim_create_user_command('GFRToggleCase', M.toggle_case_sensitive, {
+  desc = 'Toggle case sensitivity for global find and replace'
+})
+
+vim.api.nvim_create_user_command('GFRToggleRegex', M.toggle_regex_mode, {
+  desc = 'Toggle regex mode for global find and replace'
+})
+
+vim.api.nvim_create_user_command('GFRStatus', function()
+  local case_status = config.case_sensitive and 'Case-sensitive' or 'Ignore-case'
+  local regex_status = config.regex_mode and 'Regex' or 'Literal'
+  local excludes = table.concat(config.exclude_patterns, ', ')
+
+  vim.notify(string.format([[
+🔍 Global Find & Replace Status:
+  Mode: %s, %s
+  Max preview lines: %d
+  Excluded patterns: %s
+  ]], case_status, regex_status, config.max_preview_lines, excludes), vim.log.levels.INFO)
+end, {
+  desc = 'Show current global find and replace configuration'
+})
+
 return M

--- a/lua/custom/plugins/global_replace.lua
+++ b/lua/custom/plugins/global_replace.lua
@@ -1,0 +1,102 @@
+local M = {}
+
+-- Utility: simple centered floating window
+local function open_centered_window(lines, title, height)
+  local buf = vim.api.nvim_create_buf(false, true)
+  local width = 60
+  height = height or (#lines + 2)
+  local ui = vim.api.nvim_list_uis()[1]
+
+  local opts = {
+    relative = 'editor',
+    width = width,
+    height = math.min(height, ui.height - 4),
+    col = (ui.width - width) / 2,
+    row = (ui.height - height) / 2,
+    border = 'rounded',
+    style = 'minimal',
+    title = title or 'Popup',
+  }
+
+  local win = vim.api.nvim_open_win(buf, true, opts)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  return buf, win
+end
+
+-- Main function
+function M.open_find_replace_popup()
+  local buf = vim.api.nvim_create_buf(false, true)
+  local width, height = 40, 5
+  local ui = vim.api.nvim_list_uis()[1]
+  local opts = {
+    relative = 'editor',
+    width = width,
+    height = height,
+    col = (ui.width - width) / 2,
+    row = (ui.height - height) / 2,
+    border = 'rounded',
+    style = 'minimal',
+    title = ' Global Find & Replace ',
+  }
+
+  vim.api.nvim_open_win(buf, true, opts)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+    'Find: ',
+    'Replace: ',
+    '',
+    '(Press <Enter> to search, <Esc> to cancel)',
+  })
+
+  local data = { find = '', replace = '', step = 1 }
+  vim.api.nvim_win_set_cursor(0, { 1, 7 }) -- Start after "Find: "
+
+  local function close_popup()
+    vim.api.nvim_win_close(0, true)
+  end
+
+  local function run_grep(find)
+    local cmd = vim.fn.executable('rg') == 1
+      and string.format('rg --no-heading --line-number "%s"', find)
+      or string.format('grep -RIn "%s" .', find)
+    return vim.fn.systemlist(cmd)
+  end
+
+  local function show_grep_results(results)
+    if #results == 0 then
+      open_centered_window({ 'No matches found.' }, 'Results', 3)
+      return
+    end
+
+    local preview_buf, preview_win = open_centered_window(results, 'Affected Files', 20)
+    vim.api.nvim_buf_set_option(preview_buf, 'modifiable', false)
+
+    vim.keymap.set('n', '<Esc>', function()
+      vim.api.nvim_win_close(preview_win, true)
+    end, { buffer = preview_buf })
+
+    vim.keymap.set('n', '<CR>', function()
+      vim.api.nvim_win_close(preview_win, true)
+      vim.cmd('args **/*')
+      vim.cmd('argdo %s/' .. vim.fn.escape(data.find, '/') .. '/' .. vim.fn.escape(data.replace, '/') .. '/g | update')
+      print("Replaced all occurrences of '" .. data.find .. "' with '" .. data.replace .. "'.")
+    end, { buffer = preview_buf })
+  end
+
+  vim.keymap.set('i', '<CR>', function()
+    if data.step == 1 then
+      data.find = vim.api.nvim_get_current_line():sub(7)
+      data.step = 2
+      vim.api.nvim_win_set_cursor(0, { 2, 10 }) -- move to Replace line
+    else
+      data.replace = vim.api.nvim_get_current_line():sub(10)
+      close_popup()
+      local results = run_grep(data.find)
+      show_grep_results(results)
+    end
+  end, { buffer = buf })
+
+  vim.keymap.set('i', '<Esc>', close_popup, { buffer = buf })
+end
+
+vim.api.nvim_create_user_command('GlobalFindReplace', M.open_find_replace_popup, {})
+return M

--- a/lua/custom/plugins/init.lua
+++ b/lua/custom/plugins/init.lua
@@ -93,9 +93,9 @@ return {
   },
   {
     'nvim-treesitter/nvim-treesitter-textobjects',
+    branch = 'main',
     config = function()
-      require('nvim-treesitter.configs').setup {
-        textobjects = {
+      require('nvim-treesitter-textobjects').setup {
           select = {
             enable = true,
             lookahead = true,
@@ -151,7 +151,6 @@ return {
               ['<A'] = { query = '@parameter.inner', desc = 'Swap previous argument' },
             },
           },
-        },
       }
     end,
   },
@@ -237,5 +236,10 @@ return {
     'pmizio/typescript-tools.nvim',
     dependencies = { 'nvim-lua/plenary.nvim', 'neovim/nvim-lspconfig' },
     opts = {},
+  },
+  {
+    'mrcjkb/rustaceanvim',
+    version = '^7', -- Recommended
+    lazy = false, -- This plugin is already lazy
   },
 }

--- a/lua/custom/plugins/init.lua
+++ b/lua/custom/plugins/init.lua
@@ -60,7 +60,7 @@ return {
   {
     'kdheepak/lazygit.nvim',
     dependencies = {
-      'nvim-lua/plenary.nvim',
+      { 'nvim-lua/plenary.nvim', branch = 'master' },
     },
     cmd = { 'LazyGit' },
     keys = {
@@ -182,7 +182,7 @@ return {
   {
     'NeogitOrg/neogit',
     dependencies = {
-      'nvim-lua/plenary.nvim',
+      { 'nvim-lua/plenary.nvim', branch = 'master' },
       'sindrets/diffview.nvim',
       'nvim-telescope/telescope.nvim',
     },
@@ -234,7 +234,7 @@ return {
   },
   {
     'pmizio/typescript-tools.nvim',
-    dependencies = { 'nvim-lua/plenary.nvim', 'neovim/nvim-lspconfig' },
+    dependencies = { { 'nvim-lua/plenary.nvim', branch = 'master' }, 'neovim/nvim-lspconfig' },
     opts = {},
   },
   {

--- a/lua/custom/plugins/init.lua
+++ b/lua/custom/plugins/init.lua
@@ -231,6 +231,9 @@ return {
     end,
   },
   {
+    'tpope/vim-sleuth',
+  },
+  {
     'pmizio/typescript-tools.nvim',
     dependencies = { 'nvim-lua/plenary.nvim', 'neovim/nvim-lspconfig' },
     opts = {},

--- a/lua/custom/plugins/init.lua
+++ b/lua/custom/plugins/init.lua
@@ -230,4 +230,9 @@ return {
       require('blame').setup {}
     end,
   },
+  {
+    'pmizio/typescript-tools.nvim',
+    dependencies = { 'nvim-lua/plenary.nvim', 'neovim/nvim-lspconfig' },
+    opts = {},
+  },
 }

--- a/lua/kickstart/plugins/debug.lua
+++ b/lua/kickstart/plugins/debug.lua
@@ -18,7 +18,7 @@ return {
     'nvim-neotest/nvim-nio',
 
     -- Installs the debug adapters for you
-    'williamboman/mason.nvim',
+    'mason-org/mason.nvim',
     'jay-babu/mason-nvim-dap.nvim',
 
     -- Add your own debuggers here

--- a/lua/kickstart/plugins/lint.lua
+++ b/lua/kickstart/plugins/lint.lua
@@ -50,7 +50,7 @@ return {
           -- Only run the linter in buffers that you can modify in order to
           -- avoid superfluous noise, notably within the handy LSP pop-ups that
           -- describe the hovered symbol using Markdown.
-          if vim.opt_local.modifiable:get() then
+          if vim.bo.modifiable then
             lint.try_lint()
           end
         end,

--- a/lua/kickstart/plugins/neo-tree.lua
+++ b/lua/kickstart/plugins/neo-tree.lua
@@ -4,8 +4,9 @@
 return {
   'nvim-neo-tree/neo-tree.nvim',
   version = '*',
+  pkg = false,
   dependencies = {
-    'nvim-lua/plenary.nvim',
+    { 'nvim-lua/plenary.nvim', branch = 'master' },
     'nvim-tree/nvim-web-devicons',
     'MunifTanjim/nui.nvim',
   },

--- a/lua/kickstart/plugins/neo-tree.lua
+++ b/lua/kickstart/plugins/neo-tree.lua
@@ -9,7 +9,7 @@ return {
     'nvim-tree/nvim-web-devicons',
     'MunifTanjim/nui.nvim',
   },
-  cmd = 'Neotree',
+  lazy = false,
   keys = {
     { '<leader>e', ':Neotree toggle<CR>', desc = 'NeoTree toggle', silent = true },
   },


### PR DESCRIPTION
Upstream kickstart.nvim sync

  Applied all changes from the upstream repo:
  - Diagnostic config — moved to top-level before plugins, added update_in_insert, virtual_lines, jump = { float = true }
  - which-key — simplified icon config, added gr LSP Actions group
  - LSP setup — removed client_supports_method 0.10/0.11 compat shim, migrated from mason-lspconfig handlers to vim.lsp.config()/vim.lsp.enable(), removed blink.cmp as lspconfig
  dependency
  - lua_ls — replaced old callSnippet settings with new on_init pattern delegating formatting to stylua
  - conform.nvim — switched format-on-save from blacklist → whitelist
  - mini.nvim — renamed to nvim-mini/mini.nvim, fixed mini.ai keymap conflict with Neovim 0.12 incremental selection
  - Treesitter — switched to branch = 'main' with new programmatic API
  - lazydev.nvim — removed (dropped upstream)

  Compatibility fixes

  - nvim-treesitter-textobjects — pinned to branch = 'main', updated setup call from nvim-treesitter.configs to nvim-treesitter-textobjects directly
  - tree-sitter CLI — installed via cargo install tree-sitter-cli, exposed to Neovim via vim.env.PATH prepend in init.lua
  - CopilotChat deprecation warning — removed branch = 'master' from plenary dependency in copilot config
  - neo-tree .lazy.lua — added pkg = false to prevent lazy reading neo-tree's dev spec

  Bug fixes

  - ShaDa tmp files — deleted stale main.shada.tmp.* files left from unclean exits
  - plenary main branch error — root cause was lazy accumulating stale fetch = +refs/heads/main lines in plenary's .git/config; fixed with git remote set-branches origin master. Also
   added branch = 'master', version = false everywhere plenary is referenced to prevent recurrence
